### PR TITLE
Fix local image path when compression is enabled

### DIFF
--- a/lib/include/fp/fp-install.h
+++ b/lib/include/fp/fp-install.h
@@ -52,9 +52,8 @@ private:
     static inline const QString VER_TXT_PATH = u"version.txt"_s;
 
     // File Info
-    static inline const QString IMAGE_UC_EXT = u".png"_s;
-    static inline const QString IMAGE_C_EXT = u".jpg"_s;
-    static inline const QString IMAGE_C_URL_SUFFIX = u"?type=jpg"_s;
+    static inline const QString IMAGE_EXT = u".png"_s;
+    static inline const QString IMAGE_COMPRESSED_URL_SUFFIX = u"?type=jpg"_s;
 
     // Dynamic path file names
     static inline const QString SERVICES_JSON_NAME = u"services.json"_s;

--- a/lib/src/fp-install.cpp
+++ b/lib/src/fp-install.cpp
@@ -271,7 +271,7 @@ QDir Install::extrasDirectory() const { return mExtrasDirectory; }
 
 QString Install::platformLogoPath(const QString& platform)
 {
-    QString path = mPlatformLogosDirectory.absoluteFilePath(platform + IMAGE_UC_EXT);
+    QString path = mPlatformLogosDirectory.absoluteFilePath(platform + IMAGE_EXT);
     return QFile::exists(path) ? path : QString();
 }
 
@@ -279,8 +279,7 @@ QString Install::entryImageLocalPath(ImageType imageType, const QUuid& gameId) c
 {
     // Defaults to using compression if the setting isn't present
     const QDir& sourceDir = imageType == ImageType::Logo ? mEntryLogosDirectory : mEntryScreenshotsDirectory;
-    bool compressed = !mPreferences.onDemandImagesCompressed.has_value() || mPreferences.onDemandImagesCompressed.value();
-    QString localSubPath = standardImageSubPath(gameId) + (compressed ? IMAGE_C_EXT : IMAGE_UC_EXT);
+    QString localSubPath = standardImageSubPath(gameId) + IMAGE_EXT;
 
     return sourceDir.absolutePath() + '/' + localSubPath;
 }
@@ -290,10 +289,10 @@ QUrl Install::entryImageRemoteUrl(ImageType imageType, const QUuid& gameId) cons
     // Defaults to using compression if the setting isn't present
     const QString typeFolder = (imageType == ImageType::Logo ? LOGOS_FOLDER_NAME : SCREENSHOTS_FOLDER_NAME);
     bool compressed = !mPreferences.onDemandImagesCompressed.has_value() || mPreferences.onDemandImagesCompressed.value();
-    QString remoteSubPath = standardImageSubPath(gameId) + IMAGE_UC_EXT;
+    QString remoteSubPath = standardImageSubPath(gameId) + IMAGE_EXT;
 
     if(compressed)
-        remoteSubPath += IMAGE_C_URL_SUFFIX;
+        remoteSubPath += IMAGE_COMPRESSED_URL_SUFFIX;
 
     return QUrl(mPreferences.onDemandBaseUrl + typeFolder + '/' + remoteSubPath);
 }


### PR DESCRIPTION
The PNG extension is always used locally regardless of the actual image type.